### PR TITLE
fix #42: disposed widgets were not removed from contexts of InViewState

### DIFF
--- a/lib/src/inview_notifier_list.dart
+++ b/lib/src/inview_notifier_list.dart
@@ -129,7 +129,7 @@ class InViewNotifierCustomScrollView extends InViewNotifier {
 ///
 /// Using this pre-built child is entirely optional, but can improve
 /// performance significantly in some cases and is therefore a good practice.
-class InViewNotifierWidget extends StatelessWidget {
+class InViewNotifierWidget extends StatefulWidget {
   ///a required String property. This should be unique for every widget
   ///that wants to get notified.
   final String id;
@@ -153,18 +153,44 @@ class InViewNotifierWidget extends StatelessWidget {
   }) : super(key: key);
 
   @override
-  Widget build(BuildContext context) {
-    InViewState state = InViewNotifierList.of(context)!;
-    state.addContext(context: context, id: id);
+  _InViewNotifierWidgetState createState() => _InViewNotifierWidgetState();
+}
 
+class _InViewNotifierWidgetState extends State<InViewNotifierWidget> {
+  late final InViewState state;
+
+  @override
+  void initState() {
+    super.initState();
+    state = InViewNotifierList.of(context)!;
+    state.addContext(context: context, id: widget.id);
+  }
+
+  @override
+  void dispose() {
+    state.removeContext(context: context);
+    super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(InViewNotifierWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.id != widget.id) {
+      state.removeContext(context: context);
+      state.addContext(context: context, id: widget.id);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return Container(
       child: AnimatedBuilder(
         animation: state,
-        child: child,
+        child: widget.child,
         builder: (BuildContext context, Widget? child) {
-          final bool isInView = state.inView(id);
+          final bool isInView = state.inView(widget.id);
 
-          return builder(context, isInView, child);
+          return widget.builder(context, isInView, child);
         },
       ),
     );

--- a/lib/src/inview_state.dart
+++ b/lib/src/inview_state.dart
@@ -35,6 +35,10 @@ class InViewState extends ChangeNotifier {
     _contexts.add(WidgetData(context: context, id: id));
   }
 
+  void removeContext({required BuildContext context}) {
+    _contexts.removeWhere((d) => d.context == context);
+  }
+
   ///Keeps the number of widget's contexts the InViewNotifier should stored/cached for
   ///the calculations thats needed to be done to check if the widgets are inView or not.
   ///Defaults to 10 and should be greater than 1. This is done to reduce the number of calculations being performed.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: inview_notifier_list
 description: A Flutter package that builds a listview and notifies when the widgets are on screen.
-version: 2.0.0
+version: 2.0.1
 # author: Vamsi Krishna <rvamsi1993@gmail.com>
 homepage: https://github.com/rvamsikrishna/inview_notifier_list
 


### PR DESCRIPTION
Builders that use generating Widgets automatically dispose widgets when not visible. This leads to the contexts having widgets that currently are not part of the render tree. To prevent this the widgets should be stateful and remove themselves when they are disposed