### PR TITLE
feat: added `cacheExtent` to `InViewNotifierCustomScrollView`

### DIFF
--- a/lib/src/inview_notifier_list.dart
+++ b/lib/src/inview_notifier_list.dart
@@ -80,6 +80,7 @@ class InViewNotifierCustomScrollView extends InViewNotifier {
     bool shrinkWrap = false,
     Key? center,
     double anchor = 0.0,
+    double? cacheExtent,
   }) : super(
           key: key,
           initialInViewIds: initialInViewIds,
@@ -97,6 +98,7 @@ class InViewNotifierCustomScrollView extends InViewNotifier {
             primary: primary,
             shrinkWrap: shrinkWrap,
             center: center,
+            cacheExtent: cacheExtent,
           ),
         );
 


### PR DESCRIPTION
Added a support for `cacheExtent` in `InViewNotifierCustomScrollView`. In some cases it can enhance the scrolling performance for large lists of data.