### PR TITLE
v4.0.1 — Fix horizontal scroll detection, expose missing ScrollView properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [4.0.1] - 4th April 2026.
+
+**Fixes**
+
+- Fixed `deltaBottom` using `size.height` instead of `size.width` for horizontal scroll lists, causing incorrect in-view detection. ([#35](https://github.com/rvamsikrishna/inview_notifier_list/issues/35), [#40](https://github.com/rvamsikrishna/inview_notifier_list/issues/40)) — thanks to [@AlexanderFarkas](https://github.com/AlexanderFarkas) for identifying the fix in [#37](https://github.com/rvamsikrishna/inview_notifier_list/pull/37).
+
+**Features**
+
+- Exposed remaining `ListView.builder` properties: `cacheExtent`, `itemExtent`, `prototypeItem`, `findChildIndexCallback`, `addRepaintBoundaries`, `addSemanticIndexes`, `semanticChildCount`, `dragStartBehavior`, `keyboardDismissBehavior`, `restorationId`, `clipBehavior`. ([#43](https://github.com/rvamsikrishna/inview_notifier_list/issues/43), [#36](https://github.com/rvamsikrishna/inview_notifier_list/issues/36)) — thanks to [@nqhhdev](https://github.com/nqhhdev) for the initial work in [#60](https://github.com/rvamsikrishna/inview_notifier_list/pull/60).
+- Exposed remaining `CustomScrollView` properties: `cacheExtent`, `scrollBehavior`, `semanticChildCount`, `dragStartBehavior`, `keyboardDismissBehavior`, `restorationId`, `clipBehavior`.
+
+**Example App**
+
+- Added horizontal scroll example tab.
+
 ## [4.0.0] - 4th April 2026.
 
 **Breaking Changes**

--- a/example/lib/horizontal_list.dart
+++ b/example/lib/horizontal_list.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:inview_notifier_list/inview_notifier_list.dart';
+
+class HorizontalList extends StatelessWidget {
+  const HorizontalList({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      fit: StackFit.expand,
+      children: <Widget>[
+        InViewNotifierList(
+          scrollDirection: Axis.horizontal,
+          initialInViewIds: const ['0'],
+          isInViewPortCondition:
+              (double deltaTop, double deltaBottom, double vpWidth) {
+            return deltaTop < (0.5 * vpWidth) && deltaBottom > (0.5 * vpWidth);
+          },
+          itemCount: 20,
+          builder: (BuildContext context, int index) {
+            return Container(
+              width: 300.0,
+              color: Colors.blueGrey,
+              alignment: Alignment.center,
+              margin: const EdgeInsets.symmetric(horizontal: 16.0),
+              child: InViewNotifierWidget(
+                id: '$index',
+                builder: (BuildContext context, bool isInView, Widget? child) {
+                  return Container(
+                    width: 300.0,
+                    alignment: Alignment.center,
+                    color: isInView ? Colors.lightGreen : Colors.amber,
+                    child: Text(
+                      '$index : ${isInView ? 'inView' : 'notInView'}',
+                      style: Theme.of(context).textTheme.headlineSmall,
+                    ),
+                  );
+                },
+              ),
+            );
+          },
+        ),
+        IgnorePointer(
+          ignoring: true,
+          child: Align(
+            alignment: Alignment.center,
+            child: SizedBox(
+              width: 1.0,
+              height: double.infinity,
+              child: const ColoredBox(color: Colors.redAccent),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:example/csv_example.dart';
 import 'package:flutter/material.dart';
 
+import 'horizontal_list.dart';
 import 'my_list.dart';
 import 'video_list.dart';
 
@@ -31,6 +32,7 @@ class _HomePageState extends State<HomePage> {
   final List<Tab> myTabs = const <Tab>[
     Tab(text: 'Example 1'),
     Tab(text: 'Example 2'),
+    Tab(text: 'Horizontal'),
     Tab(text: 'Autoplay Video'),
     Tab(text: 'Custom Scroll View'),
   ];
@@ -45,6 +47,7 @@ class _HomePageState extends State<HomePage> {
           title: const Text('InViewNotifierList'),
           centerTitle: true,
           bottom: TabBar(
+            isScrollable: true,
             tabs: myTabs,
           ),
         ),
@@ -70,6 +73,7 @@ class _HomePageState extends State<HomePage> {
                 color: Colors.redAccent.withValues(alpha: 0.2),
               ),
             ),
+            const HorizontalList(),
             const VideoList(),
             CSVExample(),
           ],

--- a/lib/src/inview_notifier.dart
+++ b/lib/src/inview_notifier.dart
@@ -92,6 +92,7 @@ class _InViewNotifierState extends State<InViewNotifier> {
     _inViewState = InViewState(
       intialIds: widget.initialInViewIds,
       isInViewCondition: widget.isInViewPortCondition,
+      scrollDirection: widget.scrollDirection,
     );
   }
 

--- a/lib/src/inview_notifier_list.dart
+++ b/lib/src/inview_notifier_list.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:inview_notifier_list/src/inview_notifier.dart';
 
@@ -26,6 +27,18 @@ class InViewNotifierList extends InViewNotifier {
     bool? primary,
     bool shrinkWrap = false,
     bool addAutomaticKeepAlives = true,
+    bool addRepaintBoundaries = true,
+    bool addSemanticIndexes = true,
+    double? itemExtent,
+    Widget? prototypeItem,
+    ChildIndexGetter? findChildIndexCallback,
+    double? cacheExtent,
+    int? semanticChildCount,
+    DragStartBehavior dragStartBehavior = DragStartBehavior.start,
+    ScrollViewKeyboardDismissBehavior keyboardDismissBehavior =
+        ScrollViewKeyboardDismissBehavior.manual,
+    String? restorationId,
+    Clip clipBehavior = Clip.hardEdge,
   })  : assert(endNotificationOffset >= 0.0),
         super(
           child: ListView.builder(
@@ -36,9 +49,20 @@ class InViewNotifierList extends InViewNotifier {
             reverse: reverse,
             primary: primary,
             addAutomaticKeepAlives: addAutomaticKeepAlives,
+            addRepaintBoundaries: addRepaintBoundaries,
+            addSemanticIndexes: addSemanticIndexes,
             shrinkWrap: shrinkWrap,
             itemCount: itemCount,
             itemBuilder: builder,
+            itemExtent: itemExtent,
+            prototypeItem: prototypeItem,
+            findChildIndexCallback: findChildIndexCallback,
+            cacheExtent: cacheExtent,
+            semanticChildCount: semanticChildCount,
+            dragStartBehavior: dragStartBehavior,
+            keyboardDismissBehavior: keyboardDismissBehavior,
+            restorationId: restorationId,
+            clipBehavior: clipBehavior,
           ),
         );
 
@@ -69,11 +93,19 @@ class InViewNotifierCustomScrollView extends InViewNotifier {
     required super.isInViewPortCondition,
     ScrollController? controller,
     ScrollPhysics? physics,
+    ScrollBehavior? scrollBehavior,
     bool reverse = false,
     bool? primary,
     bool shrinkWrap = false,
     Key? center,
     double anchor = 0.0,
+    double? cacheExtent,
+    int? semanticChildCount,
+    DragStartBehavior dragStartBehavior = DragStartBehavior.start,
+    ScrollViewKeyboardDismissBehavior keyboardDismissBehavior =
+        ScrollViewKeyboardDismissBehavior.manual,
+    String? restorationId,
+    Clip clipBehavior = Clip.hardEdge,
   }) : super(
           child: CustomScrollView(
             slivers: slivers,
@@ -81,10 +113,17 @@ class InViewNotifierCustomScrollView extends InViewNotifier {
             controller: controller,
             scrollDirection: scrollDirection,
             physics: physics,
+            scrollBehavior: scrollBehavior,
             reverse: reverse,
             primary: primary,
             shrinkWrap: shrinkWrap,
             center: center,
+            cacheExtent: cacheExtent,
+            semanticChildCount: semanticChildCount,
+            dragStartBehavior: dragStartBehavior,
+            keyboardDismissBehavior: keyboardDismissBehavior,
+            restorationId: restorationId,
+            clipBehavior: clipBehavior,
           ),
         );
 

--- a/lib/src/inview_state.dart
+++ b/lib/src/inview_state.dart
@@ -15,11 +15,14 @@ class InViewState extends ChangeNotifier {
   ///notification whether it is in-view or not. This helps to make recognition easy.
   final List<String> _currentInViewIds = [];
   final IsInViewPortCondition? _isInViewCondition;
+  final Axis _scrollDirection;
 
   InViewState(
       {required List<String> intialIds,
+      required Axis scrollDirection,
       bool Function(double, double, double)? isInViewCondition})
-      : _isInViewCondition = isInViewCondition {
+      : _isInViewCondition = isInViewCondition,
+        _scrollDirection = scrollDirection {
     _contexts = <WidgetData>{};
     _currentInViewIds.addAll(intialIds);
   }
@@ -77,7 +80,8 @@ class InViewState extends ChangeNotifier {
       final double deltaTop = vpOffset.offset - notification.metrics.pixels;
 
       //distance from bottom of the widget to top of the viewport
-      final double deltaBottom = deltaTop + size.height;
+      final double deltaBottom = deltaTop +
+          (_scrollDirection == Axis.vertical ? size.height : size.width);
       bool isInViewport = false;
 
       //Check if the item is in the viewport by evaluating the provided widget's isInViewPortCondition condition.

--- a/lib/src/inview_state.dart
+++ b/lib/src/inview_state.dart
@@ -19,7 +19,7 @@ class InViewState extends ChangeNotifier {
 
   InViewState(
       {required List<String> intialIds,
-      required Axis scrollDirection,
+      Axis scrollDirection = Axis.vertical,
       bool Function(double, double, double)? isInViewCondition})
       : _isInViewCondition = isInViewCondition,
         _scrollDirection = scrollDirection {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: inview_notifier_list
 description: A Flutter package that builds a listview and notifies when the widgets are on screen.
-version: 4.0.0
+version: 4.0.1
 homepage: https://github.com/rvamsikrishna/inview_notifier_list
 
 environment:

--- a/test/inview_notifier_list_test.dart
+++ b/test/inview_notifier_list_test.dart
@@ -399,46 +399,61 @@ void main() {
     testWidgets('works with horizontal scroll direction',
         (WidgetTester tester) async {
       final controller = ScrollController();
+      await binding.setSurfaceSize(const Size(800, 500));
 
       await tester.pumpWidget(
         MaterialApp(
-          home: InViewNotifierList(
-            controller: controller,
-            scrollDirection: Axis.horizontal,
-            isInViewPortCondition:
-                (double deltaTop, double deltaBottom, double vpWidth) {
-              return deltaTop < (0.5 * vpWidth) &&
-                  deltaBottom > (0.5 * vpWidth);
-            },
-            itemCount: 20,
-            builder: (context, index) {
-              return InViewNotifierWidget(
-                id: '$index',
-                builder: (context, isInView, child) {
-                  return Container(
-                    key: ValueKey('h-$index'),
-                    width: 300,
-                    color: isInView ? Colors.green : Colors.red,
-                  );
-                },
-              );
-            },
+          home: SizedBox(
+            height: 500,
+            child: InViewNotifierList(
+              controller: controller,
+              scrollDirection: Axis.horizontal,
+              isInViewPortCondition:
+                  (double deltaTop, double deltaBottom, double vpWidth) {
+                return deltaTop < (0.5 * vpWidth) &&
+                    deltaBottom > (0.5 * vpWidth);
+              },
+              itemCount: 20,
+              builder: (context, index) {
+                return InViewNotifierWidget(
+                  id: '$index',
+                  builder: (context, isInView, child) {
+                    return Container(
+                      key: ValueKey('h-$index'),
+                      width: 300,
+                      height: 500,
+                      color: isInView ? Colors.green : Colors.red,
+                    );
+                  },
+                );
+              },
+            ),
           ),
         ),
       );
 
       expect(tester.takeException(), isNull);
 
-      // Scroll horizontally
-      controller.jumpTo(500.0);
+      // Each item is 300px wide. Viewport is 800px, midpoint at 400px.
+      // At offset 500: item 1 spans [−200, 100], item 2 spans [100, 400],
+      // item 3 spans [400, 700] — only item 2 straddles the midpoint
+      // (deltaTop=100 < 400, deltaBottom=400 is NOT > 400).
+      // So we need an offset where exactly one item straddles the midpoint.
+      // At offset 450: item 2 spans [150, 450] — deltaTop=150 < 400, deltaBottom=450 > 400. In-view.
+      //                item 1 spans [−150, 150] — deltaBottom=150, NOT > 400.
+      //                item 3 spans [450, 750] — deltaTop=450, NOT < 400.
+      controller.jumpTo(450.0);
       await tester.pump(const Duration(milliseconds: 300));
 
-      // Verify at least one item detected in horizontal mode
-      expect(
-        find.byWidgetPredicate(
-            (w) => w is Container && w.color == Colors.green),
-        findsWidgets,
-      );
+      // Exactly one item should be detected as in-view
+      final item2 = tester.widget<Container>(find.byKey(const ValueKey('h-2')));
+      expect(item2.color, Colors.green);
+
+      // Neighboring items should NOT be in-view
+      final item1 = tester.widget<Container>(find.byKey(const ValueKey('h-1')));
+      final item3 = tester.widget<Container>(find.byKey(const ValueKey('h-3')));
+      expect(item1.color, Colors.red);
+      expect(item3.color, Colors.red);
     });
   });
 

--- a/test/inview_state_test.dart
+++ b/test/inview_state_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:inview_notifier_list/inview_notifier_list.dart';
 
@@ -6,6 +7,7 @@ void main() {
     group('constructor and initialInViewIds', () {
       test('initializes with provided ids marked as in-view', () {
         final state = InViewState(
+          scrollDirection: Axis.vertical,
           intialIds: ['a', 'b', 'c'],
           isInViewCondition: (dt, db, vp) => true,
         );
@@ -21,6 +23,7 @@ void main() {
     group('addContext', () {
       test('adds a new context', () {
         final state = InViewState(
+          scrollDirection: Axis.vertical,
           intialIds: [],
           isInViewCondition: (dt, db, vp) => true,
         );
@@ -31,6 +34,7 @@ void main() {
 
       test('replaces context when same id is added again (dedup)', () {
         final state = InViewState(
+          scrollDirection: Axis.vertical,
           intialIds: [],
           isInViewCondition: (dt, db, vp) => true,
         );
@@ -46,6 +50,7 @@ void main() {
     group('removeContexts', () {
       test('trims contexts to the specified remaining count', () {
         final state = InViewState(
+          scrollDirection: Axis.vertical,
           intialIds: [],
           isInViewCondition: (dt, db, vp) => true,
         );
@@ -62,6 +67,7 @@ void main() {
 
       test('does nothing when letRemain >= current count', () {
         final state = InViewState(
+          scrollDirection: Axis.vertical,
           intialIds: [],
           isInViewCondition: (dt, db, vp) => true,
         );


### PR DESCRIPTION
## Description

Fix `deltaBottom` in `InViewState.onScroll()` always using `size.height`, even for horizontal lists — now correctly uses `size.width` when `scrollDirection` is `Axis.horizontal`.

Expose remaining `ListView.builder` and `CustomScrollView` properties (`cacheExtent`, `itemExtent`, `clipBehavior`, `restorationId`, etc.) so users aren't blocked by missing passthroughs.

Added horizontal scroll tab to the example app.

Thanks to @AlexanderFarkas for identifying the horizontal fix in #37 and @nqhhdev for the initial passthrough work in #60.

## Related Issue

Fixes #35, closes #40, closes #43, closes #36

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I've read the [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md)
- [x] My code follows the existing code style (`dart format .` passes)
- [x] `dart analyze --fatal-infos` reports no issues
- [x] I've added tests that prove my fix or feature works
- [x] All existing tests pass (`flutter test`)
- [x] Test coverage is at or above 90% (`flutter test --coverage`)
- [x] I've updated `CHANGELOG.md` (if user-facing change)
