### PR TITLE
Release 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@
 
 **Features**
 
+- Added `scrollViewWrapper`, an optional callback that wraps the internal `ScrollView` with an additional widget (e.g. `RefreshIndicator`, `EasyRefresh`, `SmartRefresher`, or a shimmer wrapper) while keeping in-view detection working. Available on both `InViewNotifierList` and `InViewNotifierCustomScrollView`.
 - Exposed remaining `ListView.builder` properties: `cacheExtent`, `itemExtent`, `prototypeItem`, `findChildIndexCallback`, `addRepaintBoundaries`, `addSemanticIndexes`, `semanticChildCount`, `dragStartBehavior`, `keyboardDismissBehavior`, `restorationId`, `clipBehavior`. ([#43](https://github.com/rvamsikrishna/inview_notifier_list/issues/43), [#36](https://github.com/rvamsikrishna/inview_notifier_list/issues/36)) — thanks to [@nqhhdev](https://github.com/nqhhdev) for the initial work in [#60](https://github.com/rvamsikrishna/inview_notifier_list/pull/60).
 - Exposed remaining `CustomScrollView` properties: `cacheExtent`, `scrollBehavior`, `semanticChildCount`, `dragStartBehavior`, `keyboardDismissBehavior`, `restorationId`, `clipBehavior`.
 
 **Example App**
 
 - Added horizontal scroll example tab.
+- Added pull-to-refresh example tab demonstrating `scrollViewWrapper` with `RefreshIndicator` and `EasyRefresh`.
 
 ## [4.0.0] - 4th April 2026.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [4.1.0] - 3rd July 2026.
+
+**Features**
+
+- Added `scrollViewWrapper`, an optional callback that wraps the internal `ScrollView` with an additional widget (e.g. `RefreshIndicator`, `EasyRefresh`, `SmartRefresher`, or a shimmer wrapper) while keeping in-view detection working. Available on both `InViewNotifierList` and `InViewNotifierCustomScrollView`.
+
+**Example App**
+
+- Added pull-to-refresh example tab demonstrating `scrollViewWrapper` with `RefreshIndicator` and `EasyRefresh`.
+
 ## [4.0.1] - 4th April 2026.
 
 **Fixes**
@@ -6,14 +16,12 @@
 
 **Features**
 
-- Added `scrollViewWrapper`, an optional callback that wraps the internal `ScrollView` with an additional widget (e.g. `RefreshIndicator`, `EasyRefresh`, `SmartRefresher`, or a shimmer wrapper) while keeping in-view detection working. Available on both `InViewNotifierList` and `InViewNotifierCustomScrollView`.
 - Exposed remaining `ListView.builder` properties: `cacheExtent`, `itemExtent`, `prototypeItem`, `findChildIndexCallback`, `addRepaintBoundaries`, `addSemanticIndexes`, `semanticChildCount`, `dragStartBehavior`, `keyboardDismissBehavior`, `restorationId`, `clipBehavior`. ([#43](https://github.com/rvamsikrishna/inview_notifier_list/issues/43), [#36](https://github.com/rvamsikrishna/inview_notifier_list/issues/36)) — thanks to [@nqhhdev](https://github.com/nqhhdev) for the initial work in [#60](https://github.com/rvamsikrishna/inview_notifier_list/pull/60).
 - Exposed remaining `CustomScrollView` properties: `cacheExtent`, `scrollBehavior`, `semanticChildCount`, `dragStartBehavior`, `keyboardDismissBehavior`, `restorationId`, `clipBehavior`.
 
 **Example App**
 
 - Added horizontal scroll example tab.
-- Added pull-to-refresh example tab demonstrating `scrollViewWrapper` with `RefreshIndicator` and `EasyRefresh`.
 
 ## [4.0.0] - 4th April 2026.
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,20 @@ Run the [example](https://github.com/rvamsikrishna/inview_notifier_list/tree/mas
 
 - `scrollDirection`: The axis along which the scroll view scrolls.
 
+- `scrollViewWrapper`: An optional callback that wraps the internal scroll view with an additional widget, such as a pull-to-refresh or shimmer wrapper, while keeping in-view detection working. It receives the fully built scroll view and must return a widget that contains it.
+
+  ```dart
+  InViewNotifierList(
+    scrollViewWrapper: (scrollView) => RefreshIndicator(
+      onRefresh: _onRefresh,
+      child: scrollView,
+    ),
+    // ...
+  )
+  ```
+
+  > Note: The wrapper must let `ScrollNotification` events bubble up from the inner scroll view (most widgets do by default). If the wrapper provides its own `ScrollController`, make sure it does not conflict with the one passed to `InViewNotifierList`.
+
 ##### Credits:
 
 Thanks to [Didier Boelens](https://www.didierboelens.com/) for the raw solution.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Just add the package to your dependencies in the `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  inview_notifier_list: ^4.0.1
+  inview_notifier_list: ^4.1.0
 ```
 
 ## Basic Usage

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 
 import 'horizontal_list.dart';
 import 'my_list.dart';
+import 'refresh_list.dart';
 import 'video_list.dart';
 
 void main() => runApp(const MyApp());
@@ -33,6 +34,7 @@ class _HomePageState extends State<HomePage> {
     Tab(text: 'Example 1'),
     Tab(text: 'Example 2'),
     Tab(text: 'Horizontal'),
+    Tab(text: 'Pull to Refresh'),
     Tab(text: 'Autoplay Video'),
     Tab(text: 'Custom Scroll View'),
   ];
@@ -74,6 +76,7 @@ class _HomePageState extends State<HomePage> {
               ),
             ),
             const HorizontalList(),
+            const RefreshList(),
             const VideoList(),
             CSVExample(),
           ],

--- a/example/lib/refresh_list.dart
+++ b/example/lib/refresh_list.dart
@@ -1,0 +1,135 @@
+import 'package:easy_refresh/easy_refresh.dart';
+import 'package:flutter/material.dart';
+import 'package:inview_notifier_list/inview_notifier_list.dart';
+
+enum RefreshType { flutterBuiltIn, easyRefresh }
+
+class RefreshList extends StatefulWidget {
+  const RefreshList({super.key});
+
+  @override
+  State<RefreshList> createState() => _RefreshListState();
+}
+
+class _RefreshListState extends State<RefreshList> {
+  RefreshType _selected = RefreshType.flutterBuiltIn;
+  int _itemCount = 15;
+
+  Future<void> _onRefresh() async {
+    await Future<void>.delayed(const Duration(seconds: 1));
+    setState(() => _itemCount = 15);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8.0),
+          child: SegmentedButton<RefreshType>(
+            segments: const [
+              ButtonSegment(
+                value: RefreshType.flutterBuiltIn,
+                label: Text('RefreshIndicator'),
+              ),
+              ButtonSegment(
+                value: RefreshType.easyRefresh,
+                label: Text('EasyRefresh'),
+              ),
+            ],
+            selected: {_selected},
+            onSelectionChanged: (selection) {
+              setState(() => _selected = selection.first);
+            },
+          ),
+        ),
+        Expanded(
+          child: _selected == RefreshType.flutterBuiltIn
+              ? _buildWithRefreshIndicator()
+              : _buildWithEasyRefresh(),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildWithRefreshIndicator() {
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        InViewNotifierList(
+          initialInViewIds: const ['0'],
+          isInViewPortCondition: _isInViewCondition,
+          scrollViewWrapper: (scrollView) => RefreshIndicator(
+            onRefresh: _onRefresh,
+            child: scrollView,
+          ),
+          itemCount: _itemCount,
+          builder: _itemBuilder,
+        ),
+        _inViewAreaOverlay(),
+      ],
+    );
+  }
+
+  Widget _buildWithEasyRefresh() {
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        InViewNotifierList(
+          initialInViewIds: const ['0'],
+          isInViewPortCondition: _isInViewCondition,
+          scrollViewWrapper: (scrollView) => EasyRefresh(
+            onRefresh: () async => _onRefresh(),
+            child: scrollView,
+          ),
+          itemCount: _itemCount,
+          builder: _itemBuilder,
+        ),
+        _inViewAreaOverlay(),
+      ],
+    );
+  }
+
+  bool _isInViewCondition(
+      double deltaTop, double deltaBottom, double vpHeight) {
+    return deltaTop < (0.5 * vpHeight) && deltaBottom > (0.5 * vpHeight);
+  }
+
+  Widget _itemBuilder(BuildContext context, int index) {
+    return Container(
+      width: double.infinity,
+      height: 300.0,
+      color: Colors.blueGrey,
+      alignment: Alignment.center,
+      margin: const EdgeInsets.symmetric(vertical: 50.0),
+      child: InViewNotifierWidget(
+        id: '$index',
+        builder: (BuildContext context, bool isInView, Widget? child) {
+          return Container(
+            width: double.infinity,
+            height: 250.0,
+            alignment: Alignment.center,
+            color: isInView ? Colors.lightGreen : Colors.amber,
+            child: Text(
+              '$index : ${isInView ? 'inView' : 'notInView'}',
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _inViewAreaOverlay() {
+    return IgnorePointer(
+      ignoring: true,
+      child: Align(
+        alignment: Alignment.center,
+        child: SizedBox(
+          height: 1.0,
+          child: const ColoredBox(color: Colors.redAccent),
+        ),
+      ),
+    );
+  }
+}

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -57,6 +57,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
+  easy_refresh:
+    dependency: "direct main"
+    description:
+      name: easy_refresh
+      sha256: "73eb6119f7275270cedc764fa22e724b62a2f110265945699c9bc3290681ee70"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.5.0"
   fake_async:
     dependency: transitive
     description:
@@ -102,7 +110,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "4.0.0"
+    version: "4.0.1"
   leak_tracker:
     dependency: transitive
     description:
@@ -167,6 +175,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_drawing:
+    dependency: transitive
+    description:
+      name: path_drawing
+      sha256: bbb1934c0cbb03091af082a6389ca2080345291ef07a5fa6d6e078ba8682f977
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
+  path_parsing:
+    dependency: transitive
+    description:
+      name: path_parsing
+      sha256: "883402936929eac138ee0a45da5b0f2c80f89913e6dc3bf77eb65b84b409c6ca"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   plugin_platform_interface:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   inview_notifier_list:
     path: ../
   video_player: ^2.8.0
+  easy_refresh: ^3.5.0
   cupertino_icons: ^1.0.6
 
 dev_dependencies:

--- a/lib/src/inview_notifier.dart
+++ b/lib/src/inview_notifier.dart
@@ -14,7 +14,11 @@ class InViewNotifier extends StatefulWidget {
   final List<String> initialInViewIds;
 
   ///The widget that should be displayed in the [InViewNotifier].
-  final ScrollView child;
+  ///
+  ///This is typically a [ScrollView] (e.g. [ListView], [CustomScrollView]),
+  ///but can be any widget when a [ScrollViewWrapper] is used to wrap
+  ///the scroll view with additional functionality like pull-to-refresh.
+  final Widget child;
 
   ///The distance from the bottom of the list where the [onListEndReached] should be invoked.
   final double endNotificationOffset;
@@ -34,16 +38,16 @@ class InViewNotifier extends StatefulWidget {
   ///as inView.
   final IsInViewPortCondition isInViewPortCondition;
 
-  InViewNotifier({
+  const InViewNotifier({
     super.key,
     required this.child,
     this.initialInViewIds = const [],
     this.endNotificationOffset = 0.0,
     this.onListEndReached,
     this.throttleDuration = const Duration(milliseconds: 200),
+    this.scrollDirection = Axis.vertical,
     required this.isInViewPortCondition,
-  })  : assert(endNotificationOffset >= 0.0),
-        scrollDirection = child.scrollDirection;
+  });
 
   @override
   State<InViewNotifier> createState() => _InViewNotifierState();
@@ -149,3 +153,30 @@ typedef IsInViewPortCondition = bool Function(
   double deltaBottom,
   double viewPortDimension,
 );
+
+///A function that wraps the internal [ScrollView] with an additional widget.
+///
+///This is useful for adding pull-to-refresh, shimmer wrappers, or any other
+///widget that needs to sit between the [NotificationListener] and the
+///[ScrollView].
+///
+///The [scrollView] parameter is the fully constructed [ScrollView] created
+///internally by [InViewNotifierList] or [InViewNotifierCustomScrollView].
+///
+///Example with a pull-to-refresh library:
+///```dart
+///InViewNotifierList(
+///  scrollViewWrapper: (scrollView) => SmartRefresher(
+///    controller: refreshController,
+///    child: scrollView,
+///  ),
+///  // ...
+///)
+///```
+///
+///**Important:** The wrapper must allow [ScrollNotification] events to bubble
+///up from the inner scroll view. Most widgets do this by default. If the
+///wrapper provides its own [ScrollController], ensure it does not conflict
+///with the [ScrollController] passed to [InViewNotifierList] — managing
+///scroll controller ownership is the caller's responsibility.
+typedef ScrollViewWrapper = Widget Function(Widget scrollView);

--- a/lib/src/inview_notifier_list.dart
+++ b/lib/src/inview_notifier_list.dart
@@ -64,6 +64,10 @@ class InViewNotifierList extends InViewNotifier {
               itemExtent: itemExtent,
               prototypeItem: prototypeItem,
               findChildIndexCallback: findChildIndexCallback,
+              // cacheExtent is deprecated in newer Flutter in favour of
+              // scrollCacheExtent, which does not exist on this package's
+              // minimum supported Flutter (>=3.10.0), so we keep forwarding it.
+              // ignore: deprecated_member_use
               cacheExtent: cacheExtent,
               semanticChildCount: semanticChildCount,
               dragStartBehavior: dragStartBehavior,
@@ -137,6 +141,8 @@ class InViewNotifierCustomScrollView extends InViewNotifier {
               primary: primary,
               shrinkWrap: shrinkWrap,
               center: center,
+              // cacheExtent kept for Flutter >=3.10.0 compatibility (see note above).
+              // ignore: deprecated_member_use
               cacheExtent: cacheExtent,
               semanticChildCount: semanticChildCount,
               dragStartBehavior: dragStartBehavior,

--- a/lib/src/inview_notifier_list.dart
+++ b/lib/src/inview_notifier_list.dart
@@ -10,6 +10,9 @@ import 'inview_state.dart';
 ///The constructor takes an [IndexedWidgetBuilder] which builds the children on demand.
 ///It's just like the [ListView.builder].
 class InViewNotifierList extends InViewNotifier {
+  // scrollDirection is intentionally not a super parameter — it is used both
+  // for super.scrollDirection and to configure the inner ListView.
+  // ignore: use_super_parameters
   InViewNotifierList({
     super.key,
     int? itemCount,
@@ -39,30 +42,35 @@ class InViewNotifierList extends InViewNotifier {
         ScrollViewKeyboardDismissBehavior.manual,
     String? restorationId,
     Clip clipBehavior = Clip.hardEdge,
+    ScrollViewWrapper? scrollViewWrapper,
   })  : assert(endNotificationOffset >= 0.0),
         super(
-          child: ListView.builder(
-            padding: padding,
-            controller: controller,
-            scrollDirection: scrollDirection,
-            physics: physics,
-            reverse: reverse,
-            primary: primary,
-            addAutomaticKeepAlives: addAutomaticKeepAlives,
-            addRepaintBoundaries: addRepaintBoundaries,
-            addSemanticIndexes: addSemanticIndexes,
-            shrinkWrap: shrinkWrap,
-            itemCount: itemCount,
-            itemBuilder: builder,
-            itemExtent: itemExtent,
-            prototypeItem: prototypeItem,
-            findChildIndexCallback: findChildIndexCallback,
-            cacheExtent: cacheExtent,
-            semanticChildCount: semanticChildCount,
-            dragStartBehavior: dragStartBehavior,
-            keyboardDismissBehavior: keyboardDismissBehavior,
-            restorationId: restorationId,
-            clipBehavior: clipBehavior,
+          scrollDirection: scrollDirection,
+          child: _applyWrapper(
+            scrollViewWrapper,
+            ListView.builder(
+              padding: padding,
+              controller: controller,
+              scrollDirection: scrollDirection,
+              physics: physics,
+              reverse: reverse,
+              primary: primary,
+              addAutomaticKeepAlives: addAutomaticKeepAlives,
+              addRepaintBoundaries: addRepaintBoundaries,
+              addSemanticIndexes: addSemanticIndexes,
+              shrinkWrap: shrinkWrap,
+              itemCount: itemCount,
+              itemBuilder: builder,
+              itemExtent: itemExtent,
+              prototypeItem: prototypeItem,
+              findChildIndexCallback: findChildIndexCallback,
+              cacheExtent: cacheExtent,
+              semanticChildCount: semanticChildCount,
+              dragStartBehavior: dragStartBehavior,
+              keyboardDismissBehavior: keyboardDismissBehavior,
+              restorationId: restorationId,
+              clipBehavior: clipBehavior,
+            ),
           ),
         );
 
@@ -71,6 +79,10 @@ class InViewNotifierList extends InViewNotifier {
         .getElementForInheritedWidgetOfExactType<InheritedInViewWidget>()!
         .widget as InheritedInViewWidget;
     return widget.inViewState;
+  }
+
+  static Widget _applyWrapper(ScrollViewWrapper? wrapper, Widget scrollView) {
+    return wrapper != null ? wrapper(scrollView) : scrollView;
   }
 }
 
@@ -82,6 +94,9 @@ class InViewNotifierList extends InViewNotifier {
 ///three slivers: [SliverAppBar], [SliverList], and [SliverGrid].
 
 class InViewNotifierCustomScrollView extends InViewNotifier {
+  // scrollDirection is intentionally not a super parameter — it is used both
+  // for super.scrollDirection and to configure the inner CustomScrollView.
+  // ignore: use_super_parameters
   InViewNotifierCustomScrollView({
     super.key,
     required List<Widget> slivers,
@@ -106,24 +121,29 @@ class InViewNotifierCustomScrollView extends InViewNotifier {
         ScrollViewKeyboardDismissBehavior.manual,
     String? restorationId,
     Clip clipBehavior = Clip.hardEdge,
+    ScrollViewWrapper? scrollViewWrapper,
   }) : super(
-          child: CustomScrollView(
-            slivers: slivers,
-            anchor: anchor,
-            controller: controller,
-            scrollDirection: scrollDirection,
-            physics: physics,
-            scrollBehavior: scrollBehavior,
-            reverse: reverse,
-            primary: primary,
-            shrinkWrap: shrinkWrap,
-            center: center,
-            cacheExtent: cacheExtent,
-            semanticChildCount: semanticChildCount,
-            dragStartBehavior: dragStartBehavior,
-            keyboardDismissBehavior: keyboardDismissBehavior,
-            restorationId: restorationId,
-            clipBehavior: clipBehavior,
+          scrollDirection: scrollDirection,
+          child: _applyWrapper(
+            scrollViewWrapper,
+            CustomScrollView(
+              slivers: slivers,
+              anchor: anchor,
+              controller: controller,
+              scrollDirection: scrollDirection,
+              physics: physics,
+              scrollBehavior: scrollBehavior,
+              reverse: reverse,
+              primary: primary,
+              shrinkWrap: shrinkWrap,
+              center: center,
+              cacheExtent: cacheExtent,
+              semanticChildCount: semanticChildCount,
+              dragStartBehavior: dragStartBehavior,
+              keyboardDismissBehavior: keyboardDismissBehavior,
+              restorationId: restorationId,
+              clipBehavior: clipBehavior,
+            ),
           ),
         );
 
@@ -132,6 +152,10 @@ class InViewNotifierCustomScrollView extends InViewNotifier {
         .getElementForInheritedWidgetOfExactType<InheritedInViewWidget>()!
         .widget as InheritedInViewWidget;
     return widget.inViewState;
+  }
+
+  static Widget _applyWrapper(ScrollViewWrapper? wrapper, Widget scrollView) {
+    return wrapper != null ? wrapper(scrollView) : scrollView;
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: inview_notifier_list
 description: A Flutter package that builds a listview and notifies when the widgets are on screen.
-version: 4.0.1
+version: 4.1.0
 homepage: https://github.com/rvamsikrishna/inview_notifier_list
 
 environment:

--- a/test/inview_notifier_list_test.dart
+++ b/test/inview_notifier_list_test.dart
@@ -457,6 +457,62 @@ void main() {
     });
   });
 
+  group('InViewNotifierList - scrollViewWrapper', () {
+    testWidgets('in-view detection works through a wrapper widget',
+        (WidgetTester tester) async {
+      final controller = ScrollController();
+      await binding.setSurfaceSize(const Size(500, 800));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: InViewNotifierList(
+            controller: controller,
+            isInViewPortCondition: halfwayCondition,
+            scrollViewWrapper: (scrollView) {
+              // Simulates a refresh widget wrapping the scroll view.
+              return ColoredBox(
+                color: Colors.transparent,
+                child: scrollView,
+              );
+            },
+            itemCount: 30,
+            builder: (context, index) {
+              return Container(
+                width: double.infinity,
+                height: 300.0,
+                color: Colors.blueGrey,
+                alignment: Alignment.center,
+                margin: const EdgeInsets.symmetric(vertical: 50.0),
+                child: InViewNotifierWidget(
+                  id: '$index',
+                  builder: (context, isInView, child) {
+                    return Container(
+                      key: ValueKey('w-$index'),
+                      height: 250.0,
+                      color: isInView ? Colors.green : Colors.red,
+                    );
+                  },
+                ),
+              );
+            },
+          ),
+        ),
+      );
+
+      // Scroll so that an item crosses the midpoint
+      controller.jumpTo(600.0);
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // Detection should work despite the wrapper between
+      // NotificationListener and the ListView
+      expect(
+        find.byWidgetPredicate(
+            (w) => w is Container && w.color == Colors.green),
+        findsOneWidget,
+      );
+    });
+  });
+
   group('InViewNotifierCustomScrollView', () {
     testWidgets('handles empty slivers list', (WidgetTester tester) async {
       await tester.pumpWidget(

--- a/test/inview_notifier_list_test.dart
+++ b/test/inview_notifier_list_test.dart
@@ -526,6 +526,48 @@ void main() {
 
       expect(tester.takeException(), isNull);
     });
+
+    testWidgets('in-view detection works through a scrollViewWrapper',
+        (WidgetTester tester) async {
+      final controller = ScrollController();
+      await binding.setSurfaceSize(const Size(500, 800));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: InViewNotifierCustomScrollView(
+            controller: controller,
+            isInViewPortCondition: halfwayCondition,
+            scrollViewWrapper: (scrollView) {
+              // Simulates a refresh widget wrapping the scroll view.
+              return ColoredBox(
+                color: Colors.transparent,
+                child: scrollView,
+              );
+            },
+            slivers: <Widget>[
+              SliverList(
+                delegate: SliverChildBuilderDelegate(
+                  (context, index) => TestBox(id: '$index', height: 300.0),
+                  childCount: 20,
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      // Scroll so that an item crosses the midpoint.
+      controller.jumpTo(600.0);
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // Detection should work despite the wrapper between the
+      // NotificationListener and the CustomScrollView.
+      expect(
+        find.byWidgetPredicate(
+            (w) => w is Container && w.color == Colors.lightGreen),
+        findsWidgets,
+      );
+    });
   });
 
   group('InViewNotifier - throttleDuration', () {


### PR DESCRIPTION
## Release 4.0.1

This PR ships version **4.0.1** of `inview_notifier_list`.

### ✨ Features

- **`scrollViewWrapper`** — a new optional callback that wraps the internal `ScrollView` with an additional widget (e.g. `RefreshIndicator`, `EasyRefresh`, `SmartRefresher`, or a shimmer wrapper) while keeping in-view detection fully working. Available on both `InViewNotifierList` and `InViewNotifierCustomScrollView`.
- **Full property pass-through** — exposed the remaining `ListView.builder` properties (`cacheExtent`, `itemExtent`, `prototypeItem`, `findChildIndexCallback`, `addRepaintBoundaries`, `addSemanticIndexes`, `semanticChildCount`, `dragStartBehavior`, `keyboardDismissBehavior`, `restorationId`, `clipBehavior`) and the remaining `CustomScrollView` properties (`cacheExtent`, `scrollBehavior`, `semanticChildCount`, `dragStartBehavior`, `keyboardDismissBehavior`, `restorationId`, `clipBehavior`). (#43, #36)

### 🐛 Fixes

- Fixed `deltaBottom` using `size.height` instead of `size.width` for horizontal scroll lists, which caused incorrect in-view detection. (#35, #40 — fix identified by @AlexanderFarkas in #37)

### 📱 Example App

- Added a horizontal scroll example tab.
- Added a pull-to-refresh example tab demonstrating `scrollViewWrapper` with `RefreshIndicator` and `EasyRefresh`.

### 📝 Docs

- Documented `scrollViewWrapper` in the README Properties section and the CHANGELOG.

### ✅ Quality gates

- `dart format --set-exit-if-changed .` — clean (17 files, 0 changed)
- `dart analyze --fatal-infos` — no issues
- `flutter test` — 28 passed
- Coverage — **92.37%** (above the 90% gate)
